### PR TITLE
19 exec path

### DIFF
--- a/models/exec/exec.js
+++ b/models/exec/exec.js
@@ -157,6 +157,10 @@ class Exec {
 
     static getById(id) {
 
+        if (!id.match(/^[0-9a-fA-F]{24}$/)) {
+            return Promise.reject(new errors.exec.InvalidFormatError(`id ${id} is not valid.`));
+        }
+
         return ExecModel.findById(id).then((found) => {
             if (!found) {
                 const err = new errors.exec.NotFoundError(`Exec ${id} was not found.`);

--- a/router/api/v1/exec-routes.js
+++ b/router/api/v1/exec-routes.js
@@ -284,7 +284,7 @@ r.route("/")
     });
 });
 
-r.route("/:execId")
+r.route("/:execId([0-9a-fA-F]{24})")
 /**
  * Delete an exec
  * @name delete exec

--- a/router/api/v1/exec-routes.js
+++ b/router/api/v1/exec-routes.js
@@ -16,6 +16,8 @@ const response = source("models/responses");
 const Error = response.Error;
 const PagingObject = response.PagingObject;
 
+const middleware = source("middleware");
+const requireHeaders = middleware.requireHeaders;
 
 const mongoose = require("mongoose");
 const ValidationError = mongoose.Error.ValidationError;
@@ -143,7 +145,10 @@ r.route("/")
  * @route {POST} /api/v1/execs
  * @authentication either a JWT token or an existing session.
  */
-.post(function(req, res, next) {
+.post(requireHeaders([{
+    key: "Content-Type",
+    value: "application/json",
+}]), function(req, res, next) {
 
     // if the body is not an array, send bad request
     if (!Array.isArray(req.body)) {
@@ -207,7 +212,10 @@ r.route("/")
  * @route {PATCH} /api/v1/execs
  * @authentication either a JWT token or an existing session.
  */
-.patch(function(req, res, next) {
+.patch(requireHeaders([{
+    key: "Content-Type",
+    value: "application/json",
+}]), function(req, res, next) {
     // if the body is not an array, send bad request
     if (!Array.isArray(req.body)) {
         return next(Error.BadRequest("The request is not an array"));

--- a/test/router/api/v1/exec-routes.js
+++ b/test/router/api/v1/exec-routes.js
@@ -301,6 +301,22 @@ suite("APIv1 exec routes", function() {
             });
         });
 
+        test("a valid exec object, wong content type", function() {
+            return request(app)
+            .post("/api/v1/execs")
+            .set("Content-Type", "x-www-form-urlencoded")
+            .set("Authorization", `Bearer ${userToken}`)
+            .send("name=test user1")
+            .send("email=user1@socis.ca")
+            .send("order=2")
+            .send("year=2019")
+            .send("role=admin")
+            .expect(statusCodes.BAD_REQUEST)
+            .then((res) => {
+                check.api["v1"].isGenericResponse(statusCodes.BAD_REQUEST, res.body);
+            });
+        });
+
         test("a valid object and an invalid object", function() {
 
             return request(app)
@@ -490,6 +506,23 @@ suite("APIv1 exec routes", function() {
             .set("Content-Type", "application/json")
             .set("Authorization", `Bearer ${userToken}`)
             .send(update1)
+            .expect(statusCodes.BAD_REQUEST)
+            .then((res) => {
+                check.api["v1"].isGenericResponse(statusCodes.BAD_REQUEST, res.body);
+            });
+        });
+
+        test("update a single exec, wong content type", function() {
+            return request(app)
+            .patch("/api/v1/execs")
+            .set("Content-Type", "x-www-form-urlencoded")
+            .set("Authorization", `Bearer ${userToken}`)
+            .send("id=5ccf449cd0c3a1ac66636b64")
+            .send("name=test user1")
+            .send("email=user1@socis.ca")
+            .send("order=2")
+            .send("year=2019")
+            .send("role=admin")
             .expect(statusCodes.BAD_REQUEST)
             .then((res) => {
                 check.api["v1"].isGenericResponse(statusCodes.BAD_REQUEST, res.body);

--- a/test/router/api/v1/exec-routes.js
+++ b/test/router/api/v1/exec-routes.js
@@ -496,7 +496,7 @@ suite("APIv1 exec routes", function() {
             });
         });
 
-        test("update an exec that does not exist in the db", function() {
+        test("update an exec that does not exist in the db, valid format", function() {
             let update1 = JSON.parse(JSON.stringify(pres1));
 
             update1.id = "5ccf449cd0c3a1ac66636b64";
@@ -508,6 +508,21 @@ suite("APIv1 exec routes", function() {
             .expect(statusCodes.NOT_FOUND)
             .then((res) => {
                 check.api["v1"].isGenericResponse(statusCodes.NOT_FOUND, res.body);
+            });
+        });
+
+        test("update an exec that does not exist in the db,invalid format", function() {
+            let update1 = JSON.parse(JSON.stringify(pres1));
+
+            update1.id = "execId";
+            return request(app)
+            .patch("/api/v1/execs")
+            .set("Content-Type", "application/json")
+            .set("Authorization", `Bearer ${userToken}`)
+            .send([update1])
+            .expect(statusCodes.BAD_REQUEST)
+            .then((res) => {
+                check.api["v1"].isGenericResponse(statusCodes.BAD_REQUEST, res.body);
             });
         });
 
@@ -684,9 +699,19 @@ suite("APIv1 exec routes", function() {
             });
         });
 
-        test("deleting non existent exec", function() {
+        test("deleting non existent exec, correct id format", function() {
             return request(app)
             .delete("/api/v1/execs/5ccf7ab78caf96e09f00ab22")
+            .set("Authorization", `Bearer ${userToken}`)
+            .expect(statusCodes.NOT_FOUND)
+            .then((res) => {
+                check.api["v1"].isGenericResponse(statusCodes.NOT_FOUND, res.body);
+            });
+        });
+
+        test("deleting non existent exec, bad id format", function() {
+            return request(app)
+            .delete("/api/v1/execs/execId")
             .set("Authorization", `Bearer ${userToken}`)
             .expect(statusCodes.NOT_FOUND)
             .then((res) => {


### PR DESCRIPTION
Closes #19 and closes #20.

This will make sure that the execId that is passes in to be used in the request body or in the request URL is validated to avoid casting exceptions. Also added a test to make sure that the content type is correct for the requests.