### PR TITLE
Fix npm audit warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1828,16 +1828,17 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-      "dev": true
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "espree": {
       "version": "5.0.1",


### PR DESCRIPTION
Fixed an issue with `eslint-utils` dependency I noticed upon running `npm install` the first time.

```
$ npm install
...
added 1034 packages from 993 contributors and audited 6574 packages in 11.637s
found 1 critical severity vulnerability
  run `npm audit fix` to fix them, or `npm audit` for details
$ npm audit

                       === npm audit security report ===

# Run  npm update eslint-utils --depth 2  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Critical      │ Arbitrary Code Execution                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ eslint-utils                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ eslint [dev]                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ eslint > eslint-utils                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1118                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


found 1 critical severity vulnerability in 6574 scanned packages
  run `npm audit fix` to fix 1 of them.
$ npm update eslint-utils --depth 2
+ eslint-utils@1.4.2
updated 1 package and audited 6577 packages in 3.791s
found 0 vulnerabilities
```